### PR TITLE
Casted one of the operands of this multiplication operation to a long

### DIFF
--- a/src/argouml-app/src/org/argouml/cognitive/ToDoList.java
+++ b/src/argouml-app/src/org/argouml/cognitive/ToDoList.java
@@ -196,7 +196,7 @@ public class ToDoList extends Observable implements Runnable {
             forceValidityCheck(removes);
             removes.clear();
             try {
-                Thread.sleep(SLEEP_SECONDS * 1000);
+                Thread.sleep(SLEEP_SECONDS * 1000L);
             } catch (InterruptedException ignore) {
                 LOG.log(Level.SEVERE, "InterruptedException!!!", ignore);
             }


### PR DESCRIPTION
-SLEEP_SECONDS is likely an int. When multiplied by 1000, the result is also an int.
-If SLEEP_SECONDS is large, multiplying it by 1000 can cause an overflow, resulting in an incorrect value.
-Appending L to 1000 ensures that the entire multiplication operation is performed in the long data type, preventing overflow.