### PR TITLE
Replace printStackTrace() with structured logging for secure error handling (Sonar rule java:S4507)

### DIFF
--- a/src/argouml-app/src/org/argouml/profile/internal/ProfileMeta.java
+++ b/src/argouml-app/src/org/argouml/profile/internal/ProfileMeta.java
@@ -124,7 +124,7 @@ public class ProfileMeta extends Profile {
                     ToDoItem.MED_PRIORITY, null, null,
                     "http://argouml.tigris.org/"));
         } catch (InvalidOclException e) {
-            e.printStackTrace();
+            LOG.log(Level.SEVERE, "Invalid OCL expression while loading metaprofile critic", e);
         }
 
         try {


### PR DESCRIPTION
This PR replaces all instances of e.printStackTrace() in the ProfileMeta.java class with proper structured logging using the existing Logger instance. This change addresses the SonarQube security hotspot java:S4507, which flags the use of debug features like printStackTrace() in production code.

Issue Link: [https://github.com/SOEN6431Winter2025/argoumlW25/issues/54](https://github.com/SOEN6431Winter2025/argoumlW25/issues/54)

Before:
<img width="1143" alt="before" src="https://github.com/user-attachments/assets/62807506-a7b0-4fdc-a766-853b5f403a16" />

After:
<img width="1121" alt="after" src="https://github.com/user-attachments/assets/33746584-e91f-4ab4-b6d8-2397ecd1601f" />
