### PR TITLE
Replace printStackTrace() in UserDefinedProfile.java class with structured logging for secure error handling

### DIFF
--- a/src/argouml-app/src/org/argouml/profile/UserDefinedProfile.java
+++ b/src/argouml-app/src/org/argouml/profile/UserDefinedProfile.java
@@ -772,7 +772,7 @@ public class UserDefinedProfile extends Profile {
         try {
             bis.read(buf);
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.log(Level.WARNING, "Failed to close input stream for file: " + f.getPath(), e);
         }
 
         descriptor.img = new ImageIcon(buf).getImage();


### PR DESCRIPTION
**Description**

A security vulnerability has been identified in the UserDefinedProfile.java class where exception stack traces (e.printStackTrace()) are present in the code.

---

**Tool Used** : SonarQube Cloud

---

![image](https://github.com/user-attachments/assets/16d8e6f9-4d5d-4d21-ab18-83af8ee99451)

---

**Issue Link**
[SOEN6431Winter2025#66](https://github.com/SOEN6431Winter2025/argoumlW25/issues/66)

---

**Location**
src/argouml-app/src/org/argouml/profile/UserDefinedProfile.java

---

**Solution**
Removed usage of e.printStackTrace() which exposes sensitive stack traces in production.
Replaced it with LOG.log(Level.WARNING, "Failed to close input stream for file: " + f.getPath(), e); for safer and more appropriate error logging.

![image](https://github.com/user-attachments/assets/b31858b8-41be-4102-90a1-49b2c29f3e46)
